### PR TITLE
New way for registration dependencies

### DIFF
--- a/bloc/android/app/src/main/AndroidManifest.xml
+++ b/bloc/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.flutter_template_riverpod">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <application

--- a/bloc/lib/common/extensions/get_it_extension.dart
+++ b/bloc/lib/common/extensions/get_it_extension.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/foundation.dart';
+import 'package:get_it/get_it.dart';
+
+extension GetItExtension on GetIt {
+  void registerBasedOnBuildType<T extends Object>(
+    T Function() registerFunction,
+  ) {
+    if (kDebugMode) {
+      registerLazySingleton<T>(() => registerFunction());
+    } else {
+      registerFactory<T>(() => registerFunction());
+    }
+  }
+}

--- a/riverpod/android/app/src/main/AndroidManifest.xml
+++ b/riverpod/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.flutter_template_riverpod">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <application

--- a/riverpod/lib/common/di/injector.dart
+++ b/riverpod/lib/common/di/injector.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_template_riverpod/common/extensions/get_it_extension.dart';
 import 'package:flutter_template_riverpod/todo/provider/todo_provider.dart';
 import 'package:flutter_template_riverpod/todo/provider/todo_repository.dart';
 import 'package:flutter_template_riverpod/todo/provider/todo_state.dart';
@@ -8,9 +9,11 @@ final GetIt getIt = GetIt.instance;
 
 Future<void> setupDependencies() async {
   getIt
-    ..registerSingleton(TodoRepository())
-    ..registerSingleton(TodoProvider(getIt<TodoRepository>()))
-    ..registerSingleton(StateNotifierProvider<TodoProvider, TodoState>(
-      (ref) => getIt<TodoProvider>(),
-    ));
+    ..registerLazySingleton(TodoRepository.new)
+    ..registerBasedOnBuildType(() => TodoProvider(getIt<TodoRepository>()))
+    ..registerBasedOnBuildType(
+      () => StateNotifierProvider<TodoProvider, TodoState>(
+        (ref) => getIt<TodoProvider>(),
+      ),
+    );
 }

--- a/riverpod/lib/common/extensions/get_it_extension.dart
+++ b/riverpod/lib/common/extensions/get_it_extension.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/foundation.dart';
+import 'package:get_it/get_it.dart';
+
+extension GetItExtension on GetIt {
+  void registerBasedOnBuildType<T extends Object>(
+    T Function() registerFunction,
+  ) {
+    if (kDebugMode) {
+      registerLazySingleton<T>(() => registerFunction());
+    } else {
+      registerFactory<T>(() => registerFunction());
+    }
+  }
+}

--- a/triple/android/build.gradle
+++ b/triple/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.5.21'
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         jcenter()

--- a/triple/lib/common/di/injector.dart
+++ b/triple/lib/common/di/injector.dart
@@ -1,4 +1,5 @@
 import 'package:get_it/get_it.dart';
+import 'package:triple_example/common/extensions/get_it_extension.dart';
 import 'package:triple_example/home/store/home_repository.dart';
 import 'package:triple_example/home/store/home_store.dart';
 
@@ -7,5 +8,5 @@ final GetIt getIt = GetIt.instance;
 Future<void> setupDependencies() async {
   getIt
     ..registerSingleton(HomeRepository())
-    ..registerSingleton(HomeStore(getIt<HomeRepository>()));
+    ..registerBasedOnBuildType(() => HomeStore(getIt<HomeRepository>()));
 }

--- a/triple/lib/common/extensions/get_it_extension.dart
+++ b/triple/lib/common/extensions/get_it_extension.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/foundation.dart';
+import 'package:get_it/get_it.dart';
+
+extension GetItExtension on GetIt {
+  void registerBasedOnBuildType<T extends Object>(
+    T Function() registerFunction,
+  ) {
+    if (kDebugMode) {
+      registerLazySingleton<T>(() => registerFunction());
+    } else {
+      registerFactory<T>(() => registerFunction());
+    }
+  }
+}


### PR DESCRIPTION
Проверил - сам по себе код рабочий, надо только будет проверить, насколько это удобно на реальном проекте, где в этих изменения будет практический смысл. Добавил сразу в 3 темплейта, но не уверен, что для блока это будет действительно нужно.
Без ext.kotlin_version = '1.6.21' трипл отказывался запуститься.
По этой же причине пришлось добавить package в манифестах.